### PR TITLE
Remove any references to a specific version of react.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 var React = require('react');
 
-var RadioGroup = React.createClass({displayName: 'RadioGroup',
+var RadioGroup = React.createClass({displayName: "RadioGroup",
   getInitialState: function() {
     // check the first block of comment in `setCheckedRadio`
     return {defaultValue: this.props.defaultValue};
@@ -21,8 +21,8 @@ var RadioGroup = React.createClass({displayName: 'RadioGroup',
   },
 
   render: function() {
-    return this.transferPropsTo(
-      React.createElement("div", {onChange: this.props.onChange}, 
+    return (
+      React.createElement("div", React.__spread({},  this.props, {onChange: this.props.onChange}), 
         this.props.children
       )
     );

--- a/index.jsx
+++ b/index.jsx
@@ -21,8 +21,8 @@ var RadioGroup = React.createClass({
   },
 
   render: function() {
-    return this.transferPropsTo(
-      <div onChange={this.props.onChange}>
+    return (
+      <div {...this.props} onChange={this.props.onChange}>
         {this.props.children}
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -22,11 +22,5 @@
   "bugs": {
     "url": "https://github.com/jergason/react-radio-group/issues"
   },
-  "homepage": "https://github.com/jergason/react-radio-group",
-  "devDependencies": {
-    "react-tools": "0.12.1"
-  },
-  "peerDependencies": {
-    "react": "0.12.x"
-  }
+  "homepage": "https://github.com/jergason/react-radio-group"
 }


### PR DESCRIPTION
Remove any references to a specific version of react.  I understand why some people use peerDependencies, but this is a super simple package and it will probably be more work for you to keep updating the dependency than just letting people figure out that they need react to run it.  I'm worried an error from a different package will get through when I use --force to install this with React 0.13.1.  Thanks!
